### PR TITLE
abstract JS, increase timeout, standardize names

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,17 +6,13 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>De-Militarized Time</title>
 
-	<!-- <meta http-equiv="refresh" content="1"> -->
-
 	<link rel="stylesheet" href="styles.css">
 	<script src="script.js"></script>
 </head>
 <body>
-	<!-- <p id="date">Something's messed up</p> -->
-	<canvas id="date_canvas" width="250" height="25"></canvas>
+	<canvas id="time-canvas" width="250" height="25"></canvas>
 </body>
 <footer>
-	<!-- <script>replace_date("date");</script> -->
-	<script>draw_date_to_canvas("date_canvas");</script>
+	<script>main();</script>
 </footer>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,51 +1,53 @@
-// function replace_date(id) {
-// 	let now = new Date();
+const updateCycles = 100; // specifies how many times update runs before checking theme
 
-// 	date = de_mil_date(now);
+const canvasID = "time-canvas";
+let canvas;
+let context;
 
-// 	document.getElementById(id).innerText = date;
+const canvasTextSizePx = 20;
 
-// 	console.log("date replaced");
-// }
+async function main() { // run start once, and execute continuously
+	start();
 
-async function draw_date_to_canvas(id) {
-	const canvas = document.getElementById(id);
-	const context = canvas.getContext("2d"); // Note `id` needs to point to a canvas
-	
-	function updateTheme() {
-			
-		const color_scheme = window.getComputedStyle(document.documentElement).getPropertyValue('content').replace(/"/g, '');
-		context.fillStyle = (color_scheme == "light") ? "black" : "white";
-	}
-	const text_size_px = 20;
-	context.font = `${text_size_px}px 'Courier New', Courier, monospace`; // Not super sure about this line 
-	updateTheme();
-	let i = 0;
-	let checkThemeTimeoutMs = 20; //Specifies how often the script will check for a theme update in miliseconds.
 	while (true) {
-		if (i >= checkThemeTimeoutMs) {
-			updateTheme(); //Checks for theme update
-			i = 0; //resets counter
-		}
-		context.clearRect(0, 0, canvas.width, canvas.height);
-		context.fillText(de_mil_date(new Date()), 0, 15);
-		await new Promise(
-			function(resolve, reject) {
-				// $output.append("start");
-
-				setTimeout(
-					function() {
-						resolve()
-					}, 1 // ms I presume
-				); 
-			i++;
-			}
-		) // .then(function(){$("#output")})
-		// break;
+		await execute();
 	}
 }
 
-function de_mil(number, max) {
+function start() { // This function runs once when the page refreshes
+	// Initialize the canvas
+	canvas = document.getElementById(canvasID);
+	context = canvas.getContext("2d");
+
+	context.font = `${canvasTextSizePx}px 'Courier New', Courier, monospace`;
+
+	setFillStyleFromTheme();
+}
+
+async function execute() {
+	// Run a set amount of cycles before updating theme
+	for (let i = 0; i < updateCycles; i++) {
+		drawTimeToCanvas();
+		await sleep(1);
+	} 
+	setFillStyleFromTheme();
+}
+
+function sleep(ms) {
+	return new Promise(function(resolve) { setTimeout(resolve, ms); });
+}
+
+function setFillStyleFromTheme() {
+	const colorScheme = window.getComputedStyle(document.documentElement).getPropertyValue('content').replace(/"/g, '');
+	context.fillStyle = (colorScheme == "light") ? "black" : "white";
+}
+
+function drawTimeToCanvas() {
+	context.clearRect(0, 0, canvas.width, canvas.height);
+	context.fillText(deMilitarizeDate(new Date()), 0, 15);
+}
+
+function deMilitarizeNumber(number, max) {
 	if ( (number % max) == 0 ) { return ( max + ((number % (2 * max))? "pm" : "am") )}
 
 	if ( (number <= max) ) { return (number + "am") }
@@ -53,19 +55,20 @@ function de_mil(number, max) {
 	return ( (number % max) + "pm" )
 }
 
-function de_mil_date(date) {
+function deMilitarizeDate(date) {
 	// let month = de_mil(date.getMonth(), 6);
 	// let day = de_mil(date.getDate(), 16); // 16 because I'd rather not loop inside months, and decimals aren't an option
 
-	let hour = make_length(4, de_mil(date.getHours(), 12));
-	let minute = make_length(4, de_mil(date.getMinutes(), 30));
-	let second = make_length(4, de_mil(date.getSeconds(), 30));
-	let millisecond = make_length(5, de_mil(date.getMilliseconds(), 500));
+	let hour = makeLength(deMilitarizeNumber(date.getHours(), 12), 4);
+	let minute = makeLength(deMilitarizeNumber(date.getMinutes(), 30), 4);
+	let second = makeLength(deMilitarizeNumber(date.getSeconds(), 30), 4);
+	let millisecond = makeLength(deMilitarizeNumber(date.getMilliseconds(), 500), 5);
 
 	return ( /*`${date.getDate()} ${month}/${day}/${date.getFullYear()} `*/ `${hour}:${minute}:${second}:${millisecond}` )
 }
 
-function make_length(length, string) {
-	if ( string.length > length ) { return ( string ); }
-	return ( "0".repeat(length - string.length) + string )
+function makeLength(string, minLength) {
+	if ( string.length > minLength ) { return ( string ); } // This should be impossible with the current usecase
+	
+	return ( "0".repeat(minLength - string.length) + string )
 }


### PR DESCRIPTION
Made the functions more like Unity's with start and execute, removed python-like variable and function names in favor of JavaScript conventions, increased the theme check cycle count from 20 to 100.